### PR TITLE
Do not canonicalize numbers when converting XML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 	compile 'com.google.guava:guava:18.0'
 
-	compile 'org.json:json:20160212'
+	compile 'org.json:json:20160810'
 
 	compile 'org.slf4j:slf4j-api:1.7.12'
 

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -392,7 +392,7 @@ public class MavenProject implements Project {
             unit.Data.put("SourceVersion", info.sourceVersion);
             unit.Data.put("SourceEncoding", info.sourceEncoding);
             try {
-                unit.Data.put("POM", org.json.XML.toJSONObject(IOUtils.toString(new FileInputStream(info.buildFile))));
+                unit.Data.put("POM", org.json.XML.toJSONObject(IOUtils.toString(new FileInputStream(info.buildFile)), /*keepStrings=*/ true));
             } catch (Exception e) {
                 LOGGER.warn("Unable to embed POM object into the {} unit data", unit.Name, e);
             }


### PR DESCRIPTION
Previously JSON-java converted 2.20 to 2.2.  Now it preserves the
original value as "2.20".