### PR TITLE
Make downloading parent pom's optional to reduce false negatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dependency-reduced-pom.xml
 
 /bundled-jdk/
 .vscode/
+.java-version

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -1,6 +1,8 @@
 package com.sourcegraph.javagraph;
 
 import com.google.common.collect.Iterators;
+import com.sourcegraph.javagraph.maven.vendored.*;
+import com.sourcegraph.javagraph.maven.vendored.DefaultModelBuilderFactory;
 import com.sourcegraph.javagraph.maven.plugins.MavenPlugins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -299,8 +299,7 @@ public class MavenProject implements Project {
 
         BuildAnalysis.BuildInfo info = new BuildAnalysis.BuildInfo();
 
-        // FOSSA doesn't need this and it throws errors when we can't fetch parent pom files (which happens frequently)
-        //info.attrs = proj.getPOMAttrs();
+        info.attrs = proj.getPOMAttrs();
 
         info.buildFile = proj.pomFile.toAbsolutePath().normalize().toString();
         info.dependencies = proj.listDeps();

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -392,8 +392,7 @@ public class MavenProject implements Project {
             unit.Dependencies = new ArrayList<>(info.dependencies);
             unit.Type = SourceUnit.DEFAULT_TYPE;
             unit.Data.put("POMFile", info.buildFile);
-            // NOTE: FOSSA is abandoning getting attrs, so this will be hardcoded
-            unit.Data.put("Description", "FOSSA analyzed source unit"); // info.attrs.description);
+            unit.Data.put("Description", info.attrs.description);
             unit.Data.put("SourceVersion", info.sourceVersion);
             unit.Data.put("SourceEncoding", info.sourceEncoding);
             try {

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -298,7 +298,9 @@ public class MavenProject implements Project {
 
         BuildAnalysis.BuildInfo info = new BuildAnalysis.BuildInfo();
 
-        info.attrs = proj.getPOMAttrs();
+        // FOSSA doesn't need this and it throws errors when we can't fetch parent pom files (which happens frequently)
+        //info.attrs = proj.getPOMAttrs();
+
         info.buildFile = proj.pomFile.toAbsolutePath().normalize().toString();
         info.dependencies = proj.listDeps();
         info.version = proj.getMavenProject().getVersion();
@@ -371,8 +373,10 @@ public class MavenProject implements Project {
             externalDeps.addAll(info.dependencies.stream().filter(dep ->
                     !artifactsByUnitId.containsKey(dep.groupID + '/' + dep.artifactID + '/' + dep.version)).
                     collect(Collectors.toList()));
+            
             // reading POM files to retrieve SCM repositories
-            retrieveRepoUri(info.attrs.groupID + '/' + info.attrs.artifactID, externalDeps, repositories);
+            // Commenting this out because we don't need the repoUri for anything (Alex Nuccio - 11/19/2020)
+            // retrieveRepoUri(info.attrs.groupID + '/' + info.attrs.artifactID, externalDeps, repositories);
 
         }
 
@@ -388,7 +392,8 @@ public class MavenProject implements Project {
             unit.Dependencies = new ArrayList<>(info.dependencies);
             unit.Type = SourceUnit.DEFAULT_TYPE;
             unit.Data.put("POMFile", info.buildFile);
-            unit.Data.put("Description", info.attrs.description);
+            // NOTE: FOSSA is abandoning getting attrs, so this will be hardcoded
+            unit.Data.put("Description", "FOSSA analyzed source unit"); // info.attrs.description);
             unit.Data.put("SourceVersion", info.sourceVersion);
             unit.Data.put("SourceEncoding", info.sourceEncoding);
             try {
@@ -671,6 +676,9 @@ public class MavenProject implements Project {
     /**
      * Fetches POM files for specified dependencies and extract SCM URI if there are any
      *
+     * NOTE (Alex Nuccio - 11/19/2020): All this does it set the repoURI on each of the dependencies.
+     * As of now, I don't even think we need that data.
+     * 
      * @param dependencies list of dependencies to collect URI for
      * @param repositories repositories to use when looking for external files
      */

--- a/src/main/java/com/sourcegraph/javagraph/MavenProject.java
+++ b/src/main/java/com/sourcegraph/javagraph/MavenProject.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.javagraph;
 
 import com.google.common.collect.Iterators;
-import com.sourcegraph.javagraph.maven.vendored.*;
 import com.sourcegraph.javagraph.maven.vendored.DefaultModelBuilderFactory;
 import com.sourcegraph.javagraph.maven.plugins.MavenPlugins;
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilder.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilder.java
@@ -1,0 +1,1226 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.InputLocation;
+import org.apache.maven.model.InputSource;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginManagement;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.Repository;
+import org.apache.maven.model.building.ModelProblem.Severity;
+import org.apache.maven.model.building.ModelProblem.Version;
+import org.apache.maven.model.composition.DependencyManagementImporter;
+import org.apache.maven.model.inheritance.InheritanceAssembler;
+import org.apache.maven.model.interpolation.ModelInterpolator;
+import org.apache.maven.model.io.ModelParseException;
+import org.apache.maven.model.management.DependencyManagementInjector;
+import org.apache.maven.model.management.PluginManagementInjector;
+import org.apache.maven.model.normalization.ModelNormalizer;
+import org.apache.maven.model.path.ModelPathTranslator;
+import org.apache.maven.model.path.ModelUrlNormalizer;
+import org.apache.maven.model.plugin.LifecycleBindingsInjector;
+import org.apache.maven.model.plugin.PluginConfigurationExpander;
+import org.apache.maven.model.plugin.ReportConfigurationExpander;
+import org.apache.maven.model.plugin.ReportingConverter;
+import org.apache.maven.model.profile.DefaultProfileActivationContext;
+import org.apache.maven.model.profile.ProfileInjector;
+import org.apache.maven.model.profile.ProfileSelector;
+import org.apache.maven.model.resolution.InvalidRepositoryException;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.model.resolution.UnresolvableModelException;
+import org.apache.maven.model.superpom.SuperPomProvider;
+import org.apache.maven.model.validation.ModelValidator;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Benjamin Bentmann
+ */
+@Component( role = ModelBuilder.class )
+public class DefaultModelBuilder
+    implements ModelBuilder
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultModelBuilder.class);
+
+    @Requirement
+    private ModelProcessor modelProcessor;
+
+    @Requirement
+    private ModelValidator modelValidator;
+
+    @Requirement
+    private ModelNormalizer modelNormalizer;
+
+    @Requirement
+    private ModelInterpolator modelInterpolator;
+
+    @Requirement
+    private ModelPathTranslator modelPathTranslator;
+
+    @Requirement
+    private ModelUrlNormalizer modelUrlNormalizer;
+
+    @Requirement
+    private SuperPomProvider superPomProvider;
+
+    @Requirement
+    private InheritanceAssembler inheritanceAssembler;
+
+    @Requirement
+    private ProfileSelector profileSelector;
+
+    @Requirement
+    private ProfileInjector profileInjector;
+
+    @Requirement
+    private PluginManagementInjector pluginManagementInjector;
+
+    @Requirement
+    private DependencyManagementInjector dependencyManagementInjector;
+
+    @Requirement
+    private DependencyManagementImporter dependencyManagementImporter;
+
+    @Requirement( optional = true )
+    private LifecycleBindingsInjector lifecycleBindingsInjector;
+
+    @Requirement
+    private PluginConfigurationExpander pluginConfigurationExpander;
+
+    @Requirement
+    private ReportConfigurationExpander reportConfigurationExpander;
+
+    @Requirement
+    private ReportingConverter reportingConverter;
+
+    public DefaultModelBuilder setModelProcessor( ModelProcessor modelProcessor )
+    {
+        this.modelProcessor = modelProcessor;
+        return this;
+    }
+
+    public DefaultModelBuilder setModelValidator( ModelValidator modelValidator )
+    {
+        this.modelValidator = modelValidator;
+        return this;
+    }
+
+    public DefaultModelBuilder setModelNormalizer( ModelNormalizer modelNormalizer )
+    {
+        this.modelNormalizer = modelNormalizer;
+        return this;
+    }
+
+    public DefaultModelBuilder setModelInterpolator( ModelInterpolator modelInterpolator )
+    {
+        this.modelInterpolator = modelInterpolator;
+        return this;
+    }
+
+    public DefaultModelBuilder setModelPathTranslator( ModelPathTranslator modelPathTranslator )
+    {
+        this.modelPathTranslator = modelPathTranslator;
+        return this;
+    }
+
+    public DefaultModelBuilder setModelUrlNormalizer( ModelUrlNormalizer modelUrlNormalizer )
+    {
+        this.modelUrlNormalizer = modelUrlNormalizer;
+        return this;
+    }
+
+    public DefaultModelBuilder setSuperPomProvider( SuperPomProvider superPomProvider )
+    {
+        this.superPomProvider = superPomProvider;
+        return this;
+    }
+
+    public DefaultModelBuilder setProfileSelector( ProfileSelector profileSelector )
+    {
+        this.profileSelector = profileSelector;
+        return this;
+    }
+
+    public DefaultModelBuilder setProfileInjector( ProfileInjector profileInjector )
+    {
+        this.profileInjector = profileInjector;
+        return this;
+    }
+
+    public DefaultModelBuilder setInheritanceAssembler( InheritanceAssembler inheritanceAssembler )
+    {
+        this.inheritanceAssembler = inheritanceAssembler;
+        return this;
+    }
+
+    public DefaultModelBuilder setDependencyManagementImporter( DependencyManagementImporter depMngmntImporter )
+    {
+        this.dependencyManagementImporter = depMngmntImporter;
+        return this;
+    }
+
+    public DefaultModelBuilder setDependencyManagementInjector( DependencyManagementInjector depMngmntInjector )
+    {
+        this.dependencyManagementInjector = depMngmntInjector;
+        return this;
+    }
+
+    public DefaultModelBuilder setLifecycleBindingsInjector( LifecycleBindingsInjector lifecycleBindingsInjector )
+    {
+        this.lifecycleBindingsInjector = lifecycleBindingsInjector;
+        return this;
+    }
+
+    public DefaultModelBuilder setPluginConfigurationExpander( PluginConfigurationExpander pluginConfigurationExpander )
+    {
+        this.pluginConfigurationExpander = pluginConfigurationExpander;
+        return this;
+    }
+
+    public DefaultModelBuilder setPluginManagementInjector( PluginManagementInjector pluginManagementInjector )
+    {
+        this.pluginManagementInjector = pluginManagementInjector;
+        return this;
+    }
+
+    public DefaultModelBuilder setReportConfigurationExpander( ReportConfigurationExpander reportConfigurationExpander )
+    {
+        this.reportConfigurationExpander = reportConfigurationExpander;
+        return this;
+    }
+
+    public DefaultModelBuilder setReportingConverter( ReportingConverter reportingConverter )
+    {
+        this.reportingConverter = reportingConverter;
+        return this;
+    }
+
+    public ModelBuildingResult build( ModelBuildingRequest request )
+        throws ModelBuildingException
+    {
+        DefaultModelBuildingResult result = new DefaultModelBuildingResult();
+
+        DefaultModelProblemCollector problems = new DefaultModelProblemCollector( result );
+
+        DefaultProfileActivationContext profileActivationContext = getProfileActivationContext( request );
+
+        problems.setSource( "(external profiles)" );
+        List<Profile> activeExternalProfiles =
+            profileSelector.getActiveProfiles( request.getProfiles(), profileActivationContext, problems );
+
+        result.setActiveExternalProfiles( activeExternalProfiles );
+
+        if ( !activeExternalProfiles.isEmpty() )
+        {
+            Properties profileProps = new Properties();
+            for ( Profile profile : activeExternalProfiles )
+            {
+                profileProps.putAll( profile.getProperties() );
+            }
+            profileProps.putAll( profileActivationContext.getUserProperties() );
+            profileActivationContext.setUserProperties( profileProps );
+        }
+
+        Model inputModel = readModel( request.getModelSource(), request.getPomFile(), request, problems );
+
+        problems.setRootModel( inputModel );
+
+        ModelData resultData = new ModelData( request.getModelSource(), inputModel );
+        ModelData superData = new ModelData( null, getSuperModel() );
+
+        Collection<String> parentIds = new LinkedHashSet<String>();
+        List<ModelData> lineage = new ArrayList<ModelData>();
+
+        for ( ModelData currentData = resultData; currentData != null; )
+        {
+            lineage.add( currentData );
+
+            Model tmpModel = currentData.getModel();
+
+            Model rawModel = tmpModel.clone();
+            currentData.setRawModel( rawModel );
+
+            problems.setSource( tmpModel );
+
+            modelNormalizer.mergeDuplicates( tmpModel, request, problems );
+
+            profileActivationContext.setProjectProperties( tmpModel.getProperties() );
+
+            List<Profile> activePomProfiles =
+                profileSelector.getActiveProfiles( rawModel.getProfiles(), profileActivationContext, problems );
+            currentData.setActiveProfiles( activePomProfiles );
+
+            Map<String, Activation> interpolatedActivations = getProfileActivations( rawModel, false );
+            injectProfileActivations( tmpModel, interpolatedActivations );
+
+            for ( Profile activeProfile : activePomProfiles )
+            {
+                profileInjector.injectProfile( tmpModel, activeProfile, request, problems );
+            }
+
+            if ( currentData == resultData )
+            {
+                for ( Profile activeProfile : activeExternalProfiles )
+                {
+                    profileInjector.injectProfile( tmpModel, activeProfile, request, problems );
+                }
+            }
+
+            if ( currentData == superData )
+            {
+                break;
+            }
+
+            configureResolver( request.getModelResolver(), tmpModel, problems );
+
+            ModelData parentData;
+            try {
+                parentData = readParent( tmpModel, currentData.getSource(), request, problems );
+            } catch (Exception e) {
+                LOGGER.warn("Could not read parent POM", e);
+                parentData = null;
+                LOGGER.warn("Continuing without parent POM...");
+            }
+
+            if ( parentData == null )
+            {
+                currentData = superData;
+            }
+            else if ( currentData == resultData )
+            { // First iteration - add initial parent id after version resolution.
+                currentData.setGroupId( currentData.getRawModel().getGroupId() == null
+                                            ? parentData.getGroupId()
+                                            : currentData.getRawModel().getGroupId() );
+
+                currentData.setVersion( currentData.getRawModel().getVersion() == null
+                                            ? parentData.getVersion()
+                                            : currentData.getRawModel().getVersion() );
+
+                currentData.setArtifactId( currentData.getRawModel().getArtifactId() );
+                parentIds.add( currentData.getId() );
+                // Reset - only needed for 'getId'.
+                currentData.setGroupId( null );
+                currentData.setArtifactId( null );
+                currentData.setVersion( null );
+                currentData = parentData;
+            }
+            else if ( !parentIds.add( parentData.getId() ) )
+            {
+                String message = "The parents form a cycle: ";
+                for ( String modelId : parentIds )
+                {
+                    message += modelId + " -> ";
+                }
+                message += parentData.getId();
+
+                problems.add(
+                    new ModelProblemCollectorRequest( ModelProblem.Severity.FATAL, ModelProblem.Version.BASE ).
+                    setMessage( message ) );
+
+                throw problems.newModelBuildingException();
+            }
+            else
+            {
+                currentData = parentData;
+            }
+        }
+
+        problems.setSource( inputModel );
+        checkPluginVersions( lineage, request, problems );
+
+        assembleInheritance( lineage, request, problems );
+
+        Model resultModel = resultData.getModel();
+
+        problems.setSource( resultModel );
+        problems.setRootModel( resultModel );
+
+        resultModel = interpolateModel( resultModel, request, problems );
+        resultData.setModel( resultModel );
+
+        modelUrlNormalizer.normalize( resultModel, request );
+
+        //Now the fully interpolated model is available reconfigure the resolver
+        configureResolver( request.getModelResolver(), resultModel, problems , true );
+
+        resultData.setGroupId( resultModel.getGroupId() );
+        resultData.setArtifactId( resultModel.getArtifactId() );
+        resultData.setVersion( resultModel.getVersion() );
+
+        result.setEffectiveModel( resultModel );
+
+        for ( ModelData currentData : lineage )
+        {
+            String modelId = ( currentData != superData ) ? currentData.getId() : "";
+
+            result.addModelId( modelId );
+            result.setActivePomProfiles( modelId, currentData.getActiveProfiles() );
+            result.setRawModel( modelId, currentData.getRawModel() );
+        }
+
+        if ( !request.isTwoPhaseBuilding() )
+        {
+            build( request, result );
+        }
+
+        return result;
+    }
+
+    public ModelBuildingResult build( ModelBuildingRequest request, ModelBuildingResult result )
+        throws ModelBuildingException
+    {
+        return build( request, result, new LinkedHashSet<String>() );
+    }
+
+    private ModelBuildingResult build( ModelBuildingRequest request, ModelBuildingResult result,
+                                       Collection<String> imports )
+        throws ModelBuildingException
+    {
+        Model resultModel = result.getEffectiveModel();
+
+        DefaultModelProblemCollector problems = new DefaultModelProblemCollector( result );
+        problems.setSource( resultModel );
+        problems.setRootModel( resultModel );
+
+        modelPathTranslator.alignToBaseDirectory( resultModel, resultModel.getProjectDirectory(), request );
+
+        pluginManagementInjector.injectManagement( resultModel, request, problems );
+
+        fireEvent( resultModel, request, problems, ModelBuildingEventCatapult.BUILD_EXTENSIONS_ASSEMBLED );
+
+        if ( request.isProcessPlugins() )
+        {
+            if ( lifecycleBindingsInjector == null )
+            {
+                throw new IllegalStateException( "lifecycle bindings injector is missing" );
+            }
+
+            lifecycleBindingsInjector.injectLifecycleBindings( resultModel, request, problems );
+        }
+
+        importDependencyManagement( resultModel, request, problems, imports );
+
+        dependencyManagementInjector.injectManagement( resultModel, request, problems );
+
+        modelNormalizer.injectDefaultValues( resultModel, request, problems );
+
+        if ( request.isProcessPlugins() )
+        {
+            reportConfigurationExpander.expandPluginConfiguration( resultModel, request, problems );
+
+            reportingConverter.convertReporting( resultModel, request, problems );
+
+            pluginConfigurationExpander.expandPluginConfiguration( resultModel, request, problems );
+        }
+
+        modelValidator.validateEffectiveModel( resultModel, request, problems );
+
+        if ( hasModelErrors( problems ) )
+        {
+            throw problems.newModelBuildingException();
+        }
+
+        return result;
+    }
+
+    private Model readModel( ModelSource modelSource, File pomFile, ModelBuildingRequest request,
+                             DefaultModelProblemCollector problems )
+        throws ModelBuildingException
+    {
+        Model model;
+
+        if ( modelSource == null )
+        {
+            if ( pomFile != null )
+            {
+                modelSource = new FileModelSource( pomFile );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "neither model source nor input file are specified" );
+            }
+        }
+
+        problems.setSource( modelSource.getLocation() );
+        try
+        {
+            boolean strict = request.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0;
+            InputSource source = request.isLocationTracking() ? new InputSource() : null;
+
+            Map<String, Object> options = new HashMap<String, Object>();
+            options.put( ModelProcessor.IS_STRICT, strict );
+            options.put( ModelProcessor.INPUT_SOURCE, source );
+            options.put( ModelProcessor.SOURCE, modelSource );
+
+            try
+            {
+                model = modelProcessor.read( modelSource.getInputStream(), options );
+            }
+            catch ( ModelParseException e )
+            {
+                if ( !strict )
+                {
+                    throw e;
+                }
+
+                options.put( ModelProcessor.IS_STRICT, Boolean.FALSE );
+
+                try
+                {
+                    model = modelProcessor.read( modelSource.getInputStream(), options );
+                }
+                catch ( ModelParseException ne )
+                {
+                    // still unreadable even in non-strict mode, rethrow original error
+                    throw e;
+                }
+
+                if ( pomFile != null )
+                {
+                    problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.V20 )
+                            .setMessage( "Malformed POM " + modelSource.getLocation() + ": " + e.getMessage() )
+                            .setException( e ) );
+                }
+                else
+                {
+                    problems.add( new ModelProblemCollectorRequest( Severity.WARNING, Version.V20 )
+                            .setMessage( "Malformed POM " + modelSource.getLocation() + ": " + e.getMessage() )
+                            .setException( e ) );
+                }
+            }
+
+            if ( source != null )
+            {
+                source.setModelId( ModelProblemUtils.toId( model ) );
+                source.setLocation( modelSource.getLocation() );
+            }
+        }
+        catch ( ModelParseException e )
+        {
+            problems.add( new ModelProblemCollectorRequest( Severity.FATAL, Version.BASE )
+                    .setMessage( "Non-parseable POM " + modelSource.getLocation() + ": " + e.getMessage() )
+                    .setException( e ) );
+            throw problems.newModelBuildingException();
+        }
+        catch ( IOException e )
+        {
+            String msg = e.getMessage();
+            if ( msg == null || msg.length() <= 0 )
+            {
+                // NOTE: There's java.nio.charset.MalformedInputException and sun.io.MalformedInputException
+                if ( e.getClass().getName().endsWith( "MalformedInputException" ) )
+                {
+                    msg = "Some input bytes do not match the file encoding.";
+                }
+                else
+                {
+                    msg = e.getClass().getSimpleName();
+                }
+            }
+            problems.add( new ModelProblemCollectorRequest( Severity.FATAL, Version.BASE )
+                    .setMessage( "Non-readable POM " + modelSource.getLocation() + ": " + msg )
+                    .setException( e ) );
+            throw problems.newModelBuildingException();
+        }
+
+        model.setPomFile( pomFile );
+
+        problems.setSource( model );
+        modelValidator.validateRawModel( model, request, problems );
+
+        if ( hasFatalErrors( problems ) )
+        {
+            throw problems.newModelBuildingException();
+        }
+
+        return model;
+    }
+
+    private DefaultProfileActivationContext getProfileActivationContext( ModelBuildingRequest request )
+    {
+        DefaultProfileActivationContext context = new DefaultProfileActivationContext();
+
+        context.setActiveProfileIds( request.getActiveProfileIds() );
+        context.setInactiveProfileIds( request.getInactiveProfileIds() );
+        context.setSystemProperties( request.getSystemProperties() );
+        context.setUserProperties( request.getUserProperties() );
+        context.setProjectDirectory( ( request.getPomFile() != null ) ? request.getPomFile().getParentFile() : null );
+
+        return context;
+    }
+
+    private void configureResolver( ModelResolver modelResolver, Model model, DefaultModelProblemCollector problems )
+    {
+        configureResolver( modelResolver, model, problems, false );
+    }
+
+    private void configureResolver( ModelResolver modelResolver, Model model, DefaultModelProblemCollector problems, boolean replaceRepositories )
+    {
+        if ( modelResolver == null )
+        {
+            return;
+        }
+
+        problems.setSource( model );
+
+        List<Repository> repositories = model.getRepositories();
+
+        for ( Repository repository : repositories )
+        {
+            try
+            {
+                modelResolver.addRepository( repository, replaceRepositories );
+            }
+            catch ( InvalidRepositoryException e )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                        .setMessage( "Invalid repository " + repository.getId() + ": " + e.getMessage() )
+                        .setLocation( repository.getLocation( "" ) )
+                        .setException( e ) );
+            }
+        }
+    }
+
+    private void checkPluginVersions( List<ModelData> lineage, ModelBuildingRequest request,
+                                      ModelProblemCollector problems )
+    {
+        if ( request.getValidationLevel() < ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0 )
+        {
+            return;
+        }
+
+        Map<String, Plugin> plugins = new HashMap<String, Plugin>();
+        Map<String, String> versions = new HashMap<String, String>();
+        Map<String, String> managedVersions = new HashMap<String, String>();
+
+        for ( int i = lineage.size() - 1; i >= 0; i-- )
+        {
+            Model model = lineage.get( i ).getModel();
+            Build build = model.getBuild();
+            if ( build != null )
+            {
+                for ( Plugin plugin : build.getPlugins() )
+                {
+                    String key = plugin.getKey();
+                    if ( versions.get( key ) == null )
+                    {
+                        versions.put( key, plugin.getVersion() );
+                        plugins.put( key, plugin );
+                    }
+                }
+                PluginManagement mngt = build.getPluginManagement();
+                if ( mngt != null )
+                {
+                    for ( Plugin plugin : mngt.getPlugins() )
+                    {
+                        String key = plugin.getKey();
+                        if ( managedVersions.get( key ) == null )
+                        {
+                            managedVersions.put( key, plugin.getVersion() );
+                        }
+                    }
+                }
+            }
+        }
+
+        for ( String key : versions.keySet() )
+        {
+            if ( versions.get( key ) == null && managedVersions.get( key ) == null )
+            {
+                InputLocation location = plugins.get( key ).getLocation( "" );
+                problems.add( new ModelProblemCollectorRequest( Severity.WARNING, Version.V20 )
+                        .setMessage( "'build.plugins.plugin.version' for " + key + " is missing." )
+                        .setLocation( location ) );
+            }
+        }
+    }
+
+    private void assembleInheritance( List<ModelData> lineage, ModelBuildingRequest request,
+                                      ModelProblemCollector problems )
+    {
+        for ( int i = lineage.size() - 2; i >= 0; i-- )
+        {
+            Model parent = lineage.get( i + 1 ).getModel();
+            Model child = lineage.get( i ).getModel();
+            inheritanceAssembler.assembleModelInheritance( child, parent, request, problems );
+        }
+    }
+
+    private Map<String, Activation> getProfileActivations( Model model, boolean clone )
+    {
+        Map<String, Activation> activations = new HashMap<String, Activation>();
+        for ( Profile profile : model.getProfiles() )
+        {
+            Activation activation = profile.getActivation();
+
+            if ( activation == null )
+            {
+                continue;
+            }
+
+            if ( clone )
+            {
+                activation = activation.clone();
+            }
+
+            activations.put( profile.getId(), activation );
+        }
+
+        return activations;
+    }
+
+    private void injectProfileActivations( Model model, Map<String, Activation> activations )
+    {
+        for ( Profile profile : model.getProfiles() )
+        {
+            Activation activation = profile.getActivation();
+
+            if ( activation == null )
+            {
+                continue;
+            }
+
+            // restore activation
+            profile.setActivation( activations.get( profile.getId() ) );
+        }
+    }
+
+    private Model interpolateModel( Model model, ModelBuildingRequest request, ModelProblemCollector problems )
+    {
+        // save profile activations before interpolation, since they are evaluated with limited scope
+        Map<String, Activation> originalActivations = getProfileActivations( model, true );
+
+        Model result = modelInterpolator.interpolateModel( model, model.getProjectDirectory(), request, problems );
+        result.setPomFile( model.getPomFile() );
+
+        // restore profiles with file activation to their value before full interpolation
+        injectProfileActivations( model, originalActivations );
+
+        return result;
+    }
+
+    private ModelData readParent( Model childModel, ModelSource childSource, ModelBuildingRequest request,
+                                  DefaultModelProblemCollector problems )
+        throws ModelBuildingException
+    {
+        ModelData parentData;
+
+        Parent parent = childModel.getParent();
+
+        if ( parent != null )
+        {
+            String groupId = parent.getGroupId();
+            String artifactId = parent.getArtifactId();
+            String version = parent.getVersion();
+
+            parentData = getCache( request.getModelCache(), groupId, artifactId, version, ModelCacheTag.RAW );
+
+            if ( parentData == null )
+            {
+                parentData = readParentLocally( childModel, childSource, request, problems );
+
+                if ( parentData == null )
+                {
+                    parentData = readParentExternally( childModel, request, problems );
+                }
+
+                putCache( request.getModelCache(), groupId, artifactId, version, ModelCacheTag.RAW, parentData );
+            }
+            else
+            {
+                /*
+                 * NOTE: This is a sanity check of the cache hit. If the cached parent POM was locally resolved, the
+                 * child's <relativePath> should point at that parent, too. If it doesn't, we ignore the cache and
+                 * resolve externally, to mimic the behavior if the cache didn't exist in the first place. Otherwise,
+                 * the cache would obscure a bad POM.
+                 */
+
+                File pomFile = parentData.getModel().getPomFile();
+                if ( pomFile != null )
+                {
+                    ModelSource expectedParentSource = getParentPomFile( childModel, childSource );
+
+                    if ( expectedParentSource instanceof ModelSource2
+                        && !pomFile.toURI().equals( ( (ModelSource2) expectedParentSource ).getLocationURI() ) )
+                    {
+                        parentData = readParentExternally( childModel, request, problems );
+                    }
+                }
+            }
+
+            Model parentModel = parentData.getModel();
+
+            if ( !"pom".equals( parentModel.getPackaging() ) )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                        .setMessage( "Invalid packaging for parent POM " + ModelProblemUtils.toSourceHint( parentModel )
+                                     + ", must be \"pom\" but is \"" + parentModel.getPackaging() + "\"" )
+                        .setLocation( parentModel.getLocation( "packaging" ) ) );
+            }
+        }
+        else
+        {
+            parentData = null;
+        }
+
+        return parentData;
+    }
+
+    private ModelData readParentLocally( Model childModel, ModelSource childSource, ModelBuildingRequest request,
+                                         DefaultModelProblemCollector problems )
+        throws ModelBuildingException
+    {
+        ModelSource candidateSource = getParentPomFile( childModel, childSource );
+
+        if ( candidateSource == null )
+        {
+            return null;
+        }
+
+        File pomFile = null;
+        if ( candidateSource instanceof FileModelSource )
+        {
+            pomFile = ( (FileModelSource) candidateSource ).getPomFile();
+        }
+
+        Model candidateModel = readModel( candidateSource, pomFile, request, problems );
+
+        String groupId = candidateModel.getGroupId();
+        if ( groupId == null && candidateModel.getParent() != null )
+        {
+            groupId = candidateModel.getParent().getGroupId();
+        }
+        String artifactId = candidateModel.getArtifactId();
+        String version = candidateModel.getVersion();
+        if ( version == null && candidateModel.getParent() != null )
+        {
+            version = candidateModel.getParent().getVersion();
+        }
+
+        Parent parent = childModel.getParent();
+
+        if ( groupId == null || !groupId.equals( parent.getGroupId() ) || artifactId == null
+            || !artifactId.equals( parent.getArtifactId() ) )
+        {
+            StringBuilder buffer = new StringBuilder( 256 );
+            buffer.append( "'parent.relativePath'" );
+            if ( childModel != problems.getRootModel() )
+            {
+                buffer.append( " of POM " ).append( ModelProblemUtils.toSourceHint( childModel ) );
+            }
+            buffer.append( " points at " ).append( groupId ).append( ":" ).append( artifactId );
+            buffer.append( " instead of " ).append( parent.getGroupId() ).append( ":" ).append( parent.getArtifactId() );
+            buffer.append( ", please verify your project structure" );
+
+            problems.setSource( childModel );
+            problems.add( new ModelProblemCollectorRequest( Severity.WARNING, Version.BASE )
+                    .setMessage( buffer.toString() )
+                    .setLocation( parent.getLocation( "" ) ) );
+            return null;
+        }
+        if ( version == null || !version.equals( parent.getVersion() ) )
+        {
+            return null;
+        }
+
+        ModelData parentData = new ModelData( candidateSource, candidateModel, groupId, artifactId, version );
+
+        return parentData;
+    }
+
+    private ModelSource getParentPomFile( Model childModel, ModelSource source )
+    {
+        if ( !( source instanceof ModelSource2 ) )
+        {
+            return null;
+        }
+
+        String parentPath = childModel.getParent().getRelativePath();
+
+        if ( parentPath == null || parentPath.length() <= 0 )
+        {
+            return null;
+        }
+
+        return ( (ModelSource2) source ).getRelatedSource( parentPath );
+    }
+
+    private ModelData readParentExternally( Model childModel, ModelBuildingRequest request,
+                                            DefaultModelProblemCollector problems )
+        throws ModelBuildingException
+    {
+        problems.setSource( childModel );
+
+        Parent parent = childModel.getParent().clone();
+
+        String groupId = parent.getGroupId();
+        String artifactId = parent.getArtifactId();
+        String version = parent.getVersion();
+
+        ModelResolver modelResolver = request.getModelResolver();
+
+        if ( modelResolver == null )
+        {
+            throw new IllegalArgumentException( "no model resolver provided, cannot resolve parent POM "
+                + ModelProblemUtils.toId( groupId, artifactId, version ) + " for POM "
+                + ModelProblemUtils.toSourceHint( childModel ) );
+        }
+
+        ModelSource modelSource;
+        try
+        {
+            modelSource = modelResolver.resolveModel( parent );
+        }
+        catch ( UnresolvableModelException e )
+        {
+            StringBuilder buffer = new StringBuilder( 256 );
+            buffer.append( "Non-resolvable parent POM" );
+            if ( !containsCoordinates( e.getMessage(), groupId, artifactId, version ) )
+            {
+                buffer.append( " " ).append( ModelProblemUtils.toId( groupId, artifactId, version ) );
+            }
+            if ( childModel != problems.getRootModel() )
+            {
+                buffer.append( " for " ).append( ModelProblemUtils.toId( childModel ) );
+            }
+            buffer.append( ": " ).append( e.getMessage() );
+            if ( childModel.getProjectDirectory() != null )
+            {
+                if ( parent.getRelativePath() == null || parent.getRelativePath().length() <= 0 )
+                {
+                    buffer.append( " and 'parent.relativePath' points at no local POM" );
+                }
+                else
+                {
+                    buffer.append( " and 'parent.relativePath' points at wrong local POM" );
+                }
+            }
+
+            problems.add( new ModelProblemCollectorRequest( Severity.WARNING, Version.BASE )
+                    .setMessage( buffer.toString() )
+                    .setLocation( parent.getLocation( "" ) )
+                    .setException( e ) );
+            throw problems.newModelBuildingException();
+        }
+
+        ModelBuildingRequest lenientRequest = request;
+        if ( request.getValidationLevel() > ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0 )
+        {
+            lenientRequest = new FilterModelBuildingRequest( request )
+            {
+                @Override
+                public int getValidationLevel()
+                {
+                    return ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0;
+                }
+            };
+        }
+
+        Model parentModel = readModel( modelSource, null, lenientRequest, problems );
+
+        if ( !parent.getVersion().equals( version ) )
+        {
+            if ( childModel.getVersion() == null )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.FATAL, Version.V31 ).
+                    setMessage( "Version must be a constant" ).
+                    setLocation( childModel.getLocation( "" ) ) );
+
+            }
+            else
+            {
+                if ( childModel.getVersion().indexOf( "${" ) > -1 )
+                {
+                    problems.add( new ModelProblemCollectorRequest( Severity.FATAL, Version.V31 ).
+                        setMessage( "Version must be a constant" ).
+                        setLocation( childModel.getLocation( "version" ) ) );
+
+                }
+            }
+
+            // MNG-2199: What else to check here ?
+        }
+
+        ModelData parentData = new ModelData( modelSource, parentModel, parent.getGroupId(), parent.getArtifactId(),
+                                              parent.getVersion() );
+
+        return parentData;
+    }
+
+    private Model getSuperModel()
+    {
+        return superPomProvider.getSuperModel( "4.0.0" ).clone();
+    }
+
+    private void importDependencyManagement( Model model, ModelBuildingRequest request,
+                                             DefaultModelProblemCollector problems, Collection<String> importIds )
+    {
+        DependencyManagement depMngt = model.getDependencyManagement();
+
+        if ( depMngt == null )
+        {
+            return;
+        }
+
+        String importing = model.getGroupId() + ':' + model.getArtifactId() + ':' + model.getVersion();
+
+        importIds.add( importing );
+
+        ModelResolver modelResolver = request.getModelResolver();
+
+        ModelBuildingRequest importRequest = null;
+
+        List<DependencyManagement> importMngts = null;
+
+        for ( Iterator<Dependency> it = depMngt.getDependencies().iterator(); it.hasNext(); )
+        {
+            Dependency dependency = it.next();
+
+            if ( !"pom".equals( dependency.getType() ) || !"import".equals( dependency.getScope() ) )
+            {
+                continue;
+            }
+
+            it.remove();
+
+            String groupId = dependency.getGroupId();
+            String artifactId = dependency.getArtifactId();
+            String version = dependency.getVersion();
+
+            if ( groupId == null || groupId.length() <= 0 )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                        .setMessage( "'dependencyManagement.dependencies.dependency.groupId' for "
+                                        + dependency.getManagementKey() + " is missing." )
+                        .setLocation( dependency.getLocation( "" ) ) );
+                continue;
+            }
+            if ( artifactId == null || artifactId.length() <= 0 )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                        .setMessage( "'dependencyManagement.dependencies.dependency.artifactId' for "
+                                        + dependency.getManagementKey() + " is missing." )
+                        .setLocation( dependency.getLocation( "" ) ) );
+                continue;
+            }
+            if ( version == null || version.length() <= 0 )
+            {
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                        .setMessage( "'dependencyManagement.dependencies.dependency.version' for "
+                                        + dependency.getManagementKey() + " is missing." )
+                        .setLocation( dependency.getLocation( "" ) ) );
+                continue;
+            }
+
+            String imported = groupId + ':' + artifactId + ':' + version;
+
+            if ( importIds.contains( imported ) )
+            {
+                String message = "The dependencies of type=pom and with scope=import form a cycle: ";
+                for ( String modelId : importIds )
+                {
+                    message += modelId + " -> ";
+                }
+                message += imported;
+                problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE ).setMessage( message ) );
+
+                continue;
+            }
+
+            DependencyManagement importMngt =
+                getCache( request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT );
+
+            if ( importMngt == null )
+            {
+                if ( modelResolver == null )
+                {
+                    throw new IllegalArgumentException( "no model resolver provided, cannot resolve import POM "
+                        + ModelProblemUtils.toId( groupId, artifactId, version ) + " for POM "
+                        + ModelProblemUtils.toSourceHint( model ) );
+                }
+
+                ModelSource importSource;
+                try
+                {
+                    importSource = modelResolver.resolveModel( groupId, artifactId, version );
+                }
+                catch ( UnresolvableModelException e )
+                {
+                    StringBuilder buffer = new StringBuilder( 256 );
+                    buffer.append( "Non-resolvable import POM" );
+                    if ( !containsCoordinates( e.getMessage(), groupId, artifactId, version ) )
+                    {
+                        buffer.append( " " ).append( ModelProblemUtils.toId( groupId, artifactId, version ) );
+                    }
+                    buffer.append( ": " ).append( e.getMessage() );
+
+                    problems.add( new ModelProblemCollectorRequest( Severity.ERROR, Version.BASE )
+                            .setMessage( buffer.toString() )
+                            .setLocation( dependency.getLocation( "" ) )
+                            .setException( e ) );
+                    continue;
+                }
+
+                if ( importRequest == null )
+                {
+                    importRequest = new DefaultModelBuildingRequest();
+                    importRequest.setValidationLevel( ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL );
+                    importRequest.setModelCache( request.getModelCache() );
+                    importRequest.setSystemProperties( request.getSystemProperties() );
+                    importRequest.setUserProperties( request.getUserProperties() );
+                    importRequest.setLocationTracking( request.isLocationTracking() );
+                }
+
+                importRequest.setModelSource( importSource );
+                importRequest.setModelResolver( modelResolver.newCopy() );
+
+                ModelBuildingResult importResult;
+                try
+                {
+                    importResult = build( importRequest );
+                }
+                catch ( ModelBuildingException e )
+                {
+                    problems.addAll( e.getProblems() );
+                    continue;
+                }
+
+                problems.addAll( importResult.getProblems() );
+
+                Model importModel = importResult.getEffectiveModel();
+
+                importMngt = importModel.getDependencyManagement();
+
+                if ( importMngt == null )
+                {
+                    importMngt = new DependencyManagement();
+                }
+
+                putCache( request.getModelCache(), groupId, artifactId, version, ModelCacheTag.IMPORT, importMngt );
+            }
+
+            if ( importMngts == null )
+            {
+                importMngts = new ArrayList<DependencyManagement>();
+            }
+
+            importMngts.add( importMngt );
+        }
+
+        importIds.remove( importing );
+
+        dependencyManagementImporter.importManagement( model, importMngts, request, problems );
+    }
+
+    private <T> void putCache( ModelCache modelCache, String groupId, String artifactId, String version,
+                               ModelCacheTag<T> tag, T data )
+    {
+        if ( modelCache != null )
+        {
+            modelCache.put( groupId, artifactId, version, tag.getName(), tag.intoCache( data ) );
+        }
+    }
+
+    private <T> T getCache( ModelCache modelCache, String groupId, String artifactId, String version,
+                            ModelCacheTag<T> tag )
+    {
+        if ( modelCache != null )
+        {
+            Object data = modelCache.get( groupId, artifactId, version, tag.getName() );
+            if ( data != null )
+            {
+                return tag.fromCache( tag.getType().cast( data ) );
+            }
+        }
+        return null;
+    }
+
+    private void fireEvent( Model model, ModelBuildingRequest request, ModelProblemCollector problems,
+                            ModelBuildingEventCatapult catapult )
+        throws ModelBuildingException
+    {
+        ModelBuildingListener listener = request.getModelBuildingListener();
+
+        if ( listener != null )
+        {
+            ModelBuildingEvent event = new DefaultModelBuildingEvent( model, request, problems );
+
+            catapult.fire( listener, event );
+        }
+    }
+
+    private boolean containsCoordinates( String message, String groupId, String artifactId, String version )
+    {
+        return message != null && ( groupId == null || message.contains( groupId ) )
+            && ( artifactId == null || message.contains( artifactId ) )
+            && ( version == null || message.contains( version ) );
+    }
+
+    protected boolean hasModelErrors( ModelProblemCollectorExt problems )
+    {
+        if ( problems instanceof DefaultModelProblemCollector )
+        {
+            return ( (DefaultModelProblemCollector) problems ).hasErrors();
+        }
+        else
+        {
+            // the default execution path only knows the DefaultModelProblemCollector,
+            // only reason it's not in signature is because it's package private
+            throw new IllegalStateException();
+        }
+    }
+
+    protected boolean hasFatalErrors( ModelProblemCollectorExt problems )
+    {
+        if ( problems instanceof DefaultModelProblemCollector )
+        {
+            return ( (DefaultModelProblemCollector) problems ).hasFatalErrors();
+        }
+        else
+        {
+            // the default execution path only knows the DefaultModelProblemCollector,
+            // only reason it's not in signature is because it's package private
+            throw new IllegalStateException();
+        }
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilderFactory.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilderFactory.java
@@ -1,0 +1,243 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.composition.DefaultDependencyManagementImporter;
+import org.apache.maven.model.composition.DependencyManagementImporter;
+import org.apache.maven.model.inheritance.DefaultInheritanceAssembler;
+import org.apache.maven.model.inheritance.InheritanceAssembler;
+import org.apache.maven.model.interpolation.ModelInterpolator;
+import org.apache.maven.model.interpolation.StringSearchModelInterpolator;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.model.locator.DefaultModelLocator;
+import org.apache.maven.model.locator.ModelLocator;
+import org.apache.maven.model.management.DefaultDependencyManagementInjector;
+import org.apache.maven.model.management.DefaultPluginManagementInjector;
+import org.apache.maven.model.management.DependencyManagementInjector;
+import org.apache.maven.model.management.PluginManagementInjector;
+import org.apache.maven.model.normalization.DefaultModelNormalizer;
+import org.apache.maven.model.normalization.ModelNormalizer;
+import org.apache.maven.model.path.DefaultModelPathTranslator;
+import org.apache.maven.model.path.DefaultModelUrlNormalizer;
+import org.apache.maven.model.path.DefaultPathTranslator;
+import org.apache.maven.model.path.DefaultUrlNormalizer;
+import org.apache.maven.model.path.ModelPathTranslator;
+import org.apache.maven.model.path.ModelUrlNormalizer;
+import org.apache.maven.model.path.PathTranslator;
+import org.apache.maven.model.path.UrlNormalizer;
+import org.apache.maven.model.plugin.DefaultPluginConfigurationExpander;
+import org.apache.maven.model.plugin.DefaultReportConfigurationExpander;
+import org.apache.maven.model.plugin.DefaultReportingConverter;
+import org.apache.maven.model.plugin.LifecycleBindingsInjector;
+import org.apache.maven.model.plugin.PluginConfigurationExpander;
+import org.apache.maven.model.plugin.ReportConfigurationExpander;
+import org.apache.maven.model.plugin.ReportingConverter;
+import org.apache.maven.model.profile.DefaultProfileInjector;
+import org.apache.maven.model.profile.DefaultProfileSelector;
+import org.apache.maven.model.profile.ProfileInjector;
+import org.apache.maven.model.profile.ProfileSelector;
+import org.apache.maven.model.profile.activation.FileProfileActivator;
+import org.apache.maven.model.profile.activation.JdkVersionProfileActivator;
+import org.apache.maven.model.profile.activation.OperatingSystemProfileActivator;
+import org.apache.maven.model.profile.activation.ProfileActivator;
+import org.apache.maven.model.profile.activation.PropertyProfileActivator;
+import org.apache.maven.model.superpom.DefaultSuperPomProvider;
+import org.apache.maven.model.superpom.SuperPomProvider;
+import org.apache.maven.model.validation.DefaultModelValidator;
+import org.apache.maven.model.validation.ModelValidator;
+
+/**
+ * A factory to create model builder instances when no dependency injection is available. <em>Note:</em> This class is
+ * only meant as a utility for developers that want to employ the model builder outside of the Maven build system, Maven
+ * plugins should always acquire model builder instances via dependency injection. Developers might want to subclass
+ * this factory to provide custom implementations for some of the components used by the model builder.
+ * 
+ * @author Benjamin Bentmann
+ */
+public class DefaultModelBuilderFactory
+{
+
+    protected ModelProcessor newModelProcessor()
+    {
+        DefaultModelProcessor processor = new DefaultModelProcessor();
+        processor.setModelLocator( newModelLocator() );
+        processor.setModelReader( newModelReader() );
+        return processor;
+    }
+
+    protected ModelLocator newModelLocator()
+    {
+        return new DefaultModelLocator();
+    }
+
+    protected ModelReader newModelReader()
+    {
+        return new DefaultModelReader();
+    }
+
+    protected ProfileSelector newProfileSelector()
+    {
+        DefaultProfileSelector profileSelector = new DefaultProfileSelector();
+
+        for ( ProfileActivator activator : newProfileActivators() )
+        {
+            profileSelector.addProfileActivator( activator );
+        }
+
+        return profileSelector;
+    }
+
+    protected ProfileActivator[] newProfileActivators()
+    {
+        return new ProfileActivator[] { new JdkVersionProfileActivator(), new OperatingSystemProfileActivator(),
+            new PropertyProfileActivator(), new FileProfileActivator().setPathTranslator( newPathTranslator() ) };
+    }
+
+    protected UrlNormalizer newUrlNormalizer()
+    {
+        return new DefaultUrlNormalizer();
+    }
+
+    protected PathTranslator newPathTranslator()
+    {
+        return new DefaultPathTranslator();
+    }
+
+    protected ModelInterpolator newModelInterpolator()
+    {
+        UrlNormalizer urlNormalizer = newUrlNormalizer();
+        PathTranslator pathTranslator = newPathTranslator();
+        return new StringSearchModelInterpolator().setPathTranslator( pathTranslator ).setUrlNormalizer( urlNormalizer );
+    }
+
+    protected ModelValidator newModelValidator()
+    {
+        return new DefaultModelValidator();
+    }
+
+    protected ModelNormalizer newModelNormalizer()
+    {
+        return new DefaultModelNormalizer();
+    }
+
+    protected ModelPathTranslator newModelPathTranslator()
+    {
+        return new DefaultModelPathTranslator().setPathTranslator( newPathTranslator() );
+    }
+
+    protected ModelUrlNormalizer newModelUrlNormalizer()
+    {
+        return new DefaultModelUrlNormalizer().setUrlNormalizer( newUrlNormalizer() );
+    }
+
+    protected InheritanceAssembler newInheritanceAssembler()
+    {
+        return new DefaultInheritanceAssembler();
+    }
+
+    protected ProfileInjector newProfileInjector()
+    {
+        return new DefaultProfileInjector();
+    }
+
+    protected SuperPomProvider newSuperPomProvider()
+    {
+        return new DefaultSuperPomProvider().setModelProcessor( newModelProcessor() );
+    }
+
+    protected DependencyManagementImporter newDependencyManagementImporter()
+    {
+        return new DefaultDependencyManagementImporter();
+    }
+
+    protected DependencyManagementInjector newDependencyManagementInjector()
+    {
+        return new DefaultDependencyManagementInjector();
+    }
+
+    protected LifecycleBindingsInjector newLifecycleBindingsInjector()
+    {
+        return new StubLifecycleBindingsInjector();
+    }
+
+    protected PluginManagementInjector newPluginManagementInjector()
+    {
+        return new DefaultPluginManagementInjector();
+    }
+
+    protected PluginConfigurationExpander newPluginConfigurationExpander()
+    {
+        return new DefaultPluginConfigurationExpander();
+    }
+
+    protected ReportConfigurationExpander newReportConfigurationExpander()
+    {
+        return new DefaultReportConfigurationExpander();
+    }
+
+    protected ReportingConverter newReportingConverter()
+    {
+        return new DefaultReportingConverter();
+    }
+
+    /**
+     * Creates a new model builder instance.
+     * 
+     * @return The new model builder instance, never {@code null}.
+     */
+    public DefaultModelBuilder newInstance()
+    {
+        DefaultModelBuilder modelBuilder = new DefaultModelBuilder();
+
+        modelBuilder.setModelProcessor( newModelProcessor() );
+        modelBuilder.setModelValidator( newModelValidator() );
+        modelBuilder.setModelNormalizer( newModelNormalizer() );
+        modelBuilder.setModelPathTranslator( newModelPathTranslator() );
+        modelBuilder.setModelUrlNormalizer( newModelUrlNormalizer() );
+        modelBuilder.setModelInterpolator( newModelInterpolator() );
+        modelBuilder.setInheritanceAssembler( newInheritanceAssembler() );
+        modelBuilder.setProfileInjector( newProfileInjector() );
+        modelBuilder.setProfileSelector( newProfileSelector() );
+        modelBuilder.setSuperPomProvider( newSuperPomProvider() );
+        modelBuilder.setDependencyManagementImporter( newDependencyManagementImporter() );
+        modelBuilder.setDependencyManagementInjector( newDependencyManagementInjector() );
+        modelBuilder.setLifecycleBindingsInjector( newLifecycleBindingsInjector() );
+        modelBuilder.setPluginManagementInjector( newPluginManagementInjector() );
+        modelBuilder.setPluginConfigurationExpander( newPluginConfigurationExpander() );
+        modelBuilder.setReportConfigurationExpander( newReportConfigurationExpander() );
+        modelBuilder.setReportingConverter( newReportingConverter() );
+
+        return modelBuilder;
+    }
+
+    private static class StubLifecycleBindingsInjector
+        implements LifecycleBindingsInjector
+    {
+
+        public void injectLifecycleBindings( Model model, ModelBuildingRequest request, ModelProblemCollector problems )
+        {
+        }
+
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuildingEvent.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuildingEvent.java
@@ -1,0 +1,62 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Model;
+
+/**
+ * Holds data relevant for a model building event.
+ * 
+ * @author Benjamin Bentmann
+ */
+class DefaultModelBuildingEvent
+    implements ModelBuildingEvent
+{
+
+    private final Model model;
+
+    private final ModelBuildingRequest request;
+
+    private final ModelProblemCollector problems;
+
+    public DefaultModelBuildingEvent( Model model, ModelBuildingRequest request, ModelProblemCollector problems )
+    {
+        this.model = model;
+        this.request = request;
+        this.problems = problems;
+    }
+
+    public Model getModel()
+    {
+        return model;
+    }
+
+    public ModelBuildingRequest getRequest()
+    {
+        return request;
+    }
+
+    public ModelProblemCollector getProblems()
+    {
+        return problems;
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuildingResult.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuildingResult.java
@@ -1,0 +1,176 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+import org.apache.maven.model.*;
+import org.apache.maven.model.building.*;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+
+/**
+ * Collects the output of the model builder.
+ * 
+ * @author Benjamin Bentmann
+ */
+class DefaultModelBuildingResult
+    implements ModelBuildingResult
+{
+
+    private Model effectiveModel;
+
+    private List<String> modelIds;
+
+    private Map<String, Model> rawModels;
+
+    private Map<String, List<Profile>> activePomProfiles;
+
+    private List<Profile> activeExternalProfiles;
+
+    private List<ModelProblem> problems;
+
+    public DefaultModelBuildingResult()
+    {
+        modelIds = new ArrayList<String>();
+        rawModels = new HashMap<String, Model>();
+        activePomProfiles = new HashMap<String, List<Profile>>();
+        activeExternalProfiles = new ArrayList<Profile>();
+        problems = new ArrayList<ModelProblem>();
+    }
+
+    public Model getEffectiveModel()
+    {
+        return effectiveModel;
+    }
+
+    public DefaultModelBuildingResult setEffectiveModel( Model model )
+    {
+        this.effectiveModel = model;
+
+        return this;
+    }
+
+    public List<String> getModelIds()
+    {
+        return modelIds;
+    }
+
+    public DefaultModelBuildingResult addModelId( String modelId )
+    {
+        if ( modelId == null )
+        {
+            throw new IllegalArgumentException( "no model identifier specified" );
+        }
+
+        modelIds.add( modelId );
+
+        return this;
+    }
+
+    public Model getRawModel()
+    {
+        return rawModels.get( modelIds.get( 0 ) );
+    }
+
+    public Model getRawModel( String modelId )
+    {
+        return rawModels.get( modelId );
+    }
+
+    public DefaultModelBuildingResult setRawModel( String modelId, Model rawModel )
+    {
+        if ( modelId == null )
+        {
+            throw new IllegalArgumentException( "no model identifier specified" );
+        }
+
+        rawModels.put( modelId, rawModel );
+
+        return this;
+    }
+
+    public List<Profile> getActivePomProfiles( String modelId )
+    {
+        return activePomProfiles.get( modelId );
+    }
+
+    public DefaultModelBuildingResult setActivePomProfiles( String modelId, List<Profile> activeProfiles )
+    {
+        if ( modelId == null )
+        {
+            throw new IllegalArgumentException( "no model identifier specified" );
+        }
+
+        if ( activeProfiles != null )
+        {
+            this.activePomProfiles.put( modelId, new ArrayList<Profile>( activeProfiles ) );
+        }
+        else
+        {
+            this.activePomProfiles.remove( modelId );
+        }
+
+        return this;
+    }
+
+    public List<Profile> getActiveExternalProfiles()
+    {
+        return activeExternalProfiles;
+    }
+
+    public DefaultModelBuildingResult setActiveExternalProfiles( List<Profile> activeProfiles )
+    {
+        if ( activeProfiles != null )
+        {
+            this.activeExternalProfiles = new ArrayList<Profile>( activeProfiles );
+        }
+        else
+        {
+            this.activeExternalProfiles.clear();
+        }
+
+        return this;
+    }
+
+    public List<ModelProblem> getProblems()
+    {
+        return problems;
+    }
+
+    public DefaultModelBuildingResult setProblems( List<ModelProblem> problems )
+    {
+        if ( problems != null )
+        {
+            this.problems = new ArrayList<ModelProblem>( problems );
+        }
+        else
+        {
+            this.problems.clear();
+        }
+
+        return this;
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelProblemCollector.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelProblemCollector.java
@@ -1,0 +1,199 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.ModelParseException;
+import org.apache.maven.model.building.*;
+
+/**
+ * Collects problems that are encountered during model building. The primary purpose of this component is to account for
+ * the fact that the problem reporter has/should not have information about the calling context and hence cannot provide
+ * an expressive source hint for the model problem. Instead, the source hint is configured by the model builder before
+ * it delegates to other components that potentially encounter problems. Then, the problem reporter can focus on
+ * providing a simple error message, leaving the donkey work of creating a nice model problem to this component.
+ * 
+ * @author Benjamin Bentmann
+ */
+class DefaultModelProblemCollector
+    implements ModelProblemCollectorExt
+{
+
+    private final ModelBuildingResult result;
+
+    private List<ModelProblem> problems;
+
+    private String source;
+
+    private Model sourceModel;
+
+    private Model rootModel;
+
+    private Set<ModelProblem.Severity> severities = EnumSet.noneOf( ModelProblem.Severity.class );
+
+    public DefaultModelProblemCollector( ModelBuildingResult result )
+    {
+        this.result = result;
+        this.problems = result.getProblems();
+
+        for ( ModelProblem problem : this.problems )
+        {
+            severities.add( problem.getSeverity() );
+        }
+    }
+
+    public boolean hasFatalErrors()
+    {
+        return severities.contains( ModelProblem.Severity.FATAL );
+    }
+
+    public boolean hasErrors()
+    {
+        return severities.contains( ModelProblem.Severity.ERROR ) || severities.contains( ModelProblem.Severity.FATAL );
+    }
+
+    public List<ModelProblem> getProblems()
+    {
+        return problems;
+    }
+
+    public void setSource( String source )
+    {
+        this.source = source;
+        this.sourceModel = null;
+    }
+
+    public void setSource( Model source )
+    {
+        this.sourceModel = source;
+        this.source = null;
+
+        if ( rootModel == null )
+        {
+            rootModel = source;
+        }
+    }
+
+    private String getSource()
+    {
+        if ( source == null && sourceModel != null )
+        {
+            source = ModelProblemUtils.toPath( sourceModel );
+        }
+        return source;
+    }
+
+    private String getModelId()
+    {
+        return ModelProblemUtils.toId( sourceModel );
+    }
+
+    public void setRootModel( Model rootModel )
+    {
+        this.rootModel = rootModel;
+    }
+
+    public Model getRootModel()
+    {
+        return rootModel;
+    }
+
+    public String getRootModelId()
+    {
+        return ModelProblemUtils.toId( rootModel );
+    }
+
+    public void add( ModelProblem problem )
+    {
+        problems.add( problem );
+
+        severities.add( problem.getSeverity() );
+    }
+
+    public void addAll( List<ModelProblem> problems )
+    {
+        this.problems.addAll( problems );
+
+        for ( ModelProblem problem : problems )
+        {
+            severities.add( problem.getSeverity() );
+        }
+    }
+
+    public void add( ModelProblemCollectorRequest req )
+    {
+        int line = -1;
+        int column = -1;
+        String source = null;
+        String modelId = null;
+
+        if ( req.getLocation() != null )
+        {
+            line = req.getLocation().getLineNumber();
+            column = req.getLocation().getColumnNumber();
+            if ( req.getLocation().getSource() != null )
+            {
+                modelId = req.getLocation().getSource().getModelId();
+                source = req.getLocation().getSource().getLocation();
+            }
+        }
+
+        if ( modelId == null )
+        {
+            modelId = getModelId();
+            source = getSource();
+        }
+
+        if ( line <= 0 && column <= 0 && req.getException() instanceof ModelParseException )
+        {
+            ModelParseException e = (ModelParseException) req.getException();
+            line = e.getLineNumber();
+            column = e.getColumnNumber();
+        }
+
+        ModelProblem problem =
+            new DefaultModelProblem( req.getMessage(), req.getSeverity(), req.getVersion(), source, line, column,
+                                     modelId, req.getException() );
+
+        add( problem );
+    }
+
+    public ModelBuildingException newModelBuildingException()
+    {
+        ModelBuildingResult result = this.result;
+        if ( result.getModelIds().isEmpty() )
+        {
+            DefaultModelBuildingResult tmp = new DefaultModelBuildingResult();
+            tmp.setEffectiveModel( result.getEffectiveModel() );
+            tmp.setProblems( getProblems() );
+            tmp.setActiveExternalProfiles( result.getActiveExternalProfiles() );
+            String id = getRootModelId();
+            tmp.addModelId( id );
+            tmp.setRawModel( id, getRootModel() );
+            result = tmp;
+        }
+        return new ModelBuildingException( result );
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/FilterModelBuildingRequest.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/FilterModelBuildingRequest.java
@@ -1,0 +1,228 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.resolution.ModelResolver;
+
+/**
+ * A model building request that delegates all methods invocations to another request, meant for easy transformations by
+ * subclassing.
+ * 
+ * @author Benjamin Bentmann
+ */
+class FilterModelBuildingRequest
+    implements ModelBuildingRequest
+{
+
+    protected ModelBuildingRequest request;
+
+    public FilterModelBuildingRequest( ModelBuildingRequest request )
+    {
+        this.request = request;
+    }
+
+    public File getPomFile()
+    {
+        return request.getPomFile();
+    }
+
+    public FilterModelBuildingRequest setPomFile( File pomFile )
+    {
+        request.setPomFile( pomFile );
+
+        return this;
+    }
+
+    public ModelSource getModelSource()
+    {
+        return request.getModelSource();
+    }
+
+    public FilterModelBuildingRequest setModelSource( ModelSource modelSource )
+    {
+        request.setModelSource( modelSource );
+
+        return this;
+    }
+
+    public int getValidationLevel()
+    {
+        return request.getValidationLevel();
+    }
+
+    public FilterModelBuildingRequest setValidationLevel( int validationLevel )
+    {
+        request.setValidationLevel( validationLevel );
+
+        return this;
+    }
+
+    public boolean isProcessPlugins()
+    {
+        return request.isProcessPlugins();
+    }
+
+    public FilterModelBuildingRequest setProcessPlugins( boolean processPlugins )
+    {
+        request.setProcessPlugins( processPlugins );
+
+        return this;
+    }
+
+    public boolean isTwoPhaseBuilding()
+    {
+        return request.isTwoPhaseBuilding();
+    }
+
+    public FilterModelBuildingRequest setTwoPhaseBuilding( boolean twoPhaseBuilding )
+    {
+        request.setTwoPhaseBuilding( twoPhaseBuilding );
+
+        return this;
+    }
+
+    public boolean isLocationTracking()
+    {
+        return request.isLocationTracking();
+    }
+
+    public FilterModelBuildingRequest setLocationTracking( boolean locationTracking )
+    {
+        request.setLocationTracking( locationTracking );
+
+        return this;
+    }
+
+    public List<Profile> getProfiles()
+    {
+        return request.getProfiles();
+    }
+
+    public FilterModelBuildingRequest setProfiles( List<Profile> profiles )
+    {
+        request.setProfiles( profiles );
+
+        return this;
+    }
+
+    public List<String> getActiveProfileIds()
+    {
+        return request.getActiveProfileIds();
+    }
+
+    public FilterModelBuildingRequest setActiveProfileIds( List<String> activeProfileIds )
+    {
+        request.setActiveProfileIds( activeProfileIds );
+
+        return this;
+    }
+
+    public List<String> getInactiveProfileIds()
+    {
+        return request.getInactiveProfileIds();
+    }
+
+    public FilterModelBuildingRequest setInactiveProfileIds( List<String> inactiveProfileIds )
+    {
+        request.setInactiveProfileIds( inactiveProfileIds );
+
+        return this;
+    }
+
+    public Properties getSystemProperties()
+    {
+        return request.getSystemProperties();
+    }
+
+    public FilterModelBuildingRequest setSystemProperties( Properties systemProperties )
+    {
+        request.setSystemProperties( systemProperties );
+
+        return this;
+    }
+
+    public Properties getUserProperties()
+    {
+        return request.getUserProperties();
+    }
+
+    public FilterModelBuildingRequest setUserProperties( Properties userProperties )
+    {
+        request.setUserProperties( userProperties );
+
+        return this;
+    }
+
+    public Date getBuildStartTime()
+    {
+        return request.getBuildStartTime();
+    }
+
+    public ModelBuildingRequest setBuildStartTime( Date buildStartTime )
+    {
+        request.setBuildStartTime( buildStartTime );
+
+        return this;
+    }
+
+    public ModelResolver getModelResolver()
+    {
+        return request.getModelResolver();
+    }
+
+    public FilterModelBuildingRequest setModelResolver( ModelResolver modelResolver )
+    {
+        request.setModelResolver( modelResolver );
+
+        return this;
+    }
+
+    public ModelBuildingListener getModelBuildingListener()
+    {
+        return request.getModelBuildingListener();
+    }
+
+    public ModelBuildingRequest setModelBuildingListener( ModelBuildingListener modelBuildingListener )
+    {
+        request.setModelBuildingListener( modelBuildingListener );
+
+        return this;
+    }
+
+    public ModelCache getModelCache()
+    {
+        return request.getModelCache();
+    }
+
+    public FilterModelBuildingRequest setModelCache( ModelCache modelCache )
+    {
+        request.setModelCache( modelCache );
+
+        return this;
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelBuildingEventCatapult.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelBuildingEventCatapult.java
@@ -1,0 +1,48 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+import org.apache.maven.model.building.*;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Assists in firing events from a generic method by abstracting from the actual callback method to be called on the
+ * listener.
+ *
+ * @author Benjamin Bentmann
+ */
+interface ModelBuildingEventCatapult
+{
+
+    /**
+     * Notifies the specified listener of the given event.
+     *
+     * @param listener The listener to notify, must not be {@code null}.
+     * @param event The event to fire, must not be {@code null}.
+     */
+    void fire( ModelBuildingListener listener, ModelBuildingEvent event );
+
+    ModelBuildingEventCatapult BUILD_EXTENSIONS_ASSEMBLED = new ModelBuildingEventCatapult()
+    {
+        public void fire( ModelBuildingListener listener, ModelBuildingEvent event )
+        {
+            listener.buildExtensionsAssembled( event );
+        }
+    };
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelCacheTag.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelCacheTag.java
@@ -1,0 +1,124 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+
+/**
+ * Describes a tag used by the model builder to access a {@link ModelCache}. This interface basically aggregates a name
+ * and a class to provide some type safety when working with the otherwise untyped cache.
+ *
+ * @author Benjamin Bentmann
+ * @param <T> The type of data associated with the tag.
+ */
+interface ModelCacheTag<T>
+{
+
+    /**
+     * Gets the name of the tag.
+     *
+     * @return The name of the tag, must not be {@code null}.
+     */
+    String getName();
+
+    /**
+     * Gets the type of data associated with this tag.
+     *
+     * @return The type of data, must not be {@code null}.
+     */
+    Class<T> getType();
+
+    /**
+     * Creates a copy of the data suitable for storage in the cache. The original data to store can be mutated after the
+     * cache is populated but the state of the cache must not change so we need to make a copy.
+     *
+     * @param data The data to store in the cache, must not be {@code null}.
+     * @return The data being stored in the cache, never {@code null}.
+     */
+    T intoCache( T data );
+
+    /**
+     * Creates a copy of the data suitable for retrieval from the cache. The retrieved data can be mutated after the
+     * cache is queried but the state of the cache must not change so we need to make a copy.
+     *
+     * @param data The data to retrieve from the cache, must not be {@code null}.
+     * @return The data being retrieved from the cache, never {@code null}.
+     */
+    T fromCache( T data );
+
+    /**
+     * The tag used to denote raw model data.
+     */
+    ModelCacheTag<ModelData> RAW = new ModelCacheTag<ModelData>()
+    {
+
+        public String getName()
+        {
+            return "raw";
+        }
+
+        public Class<ModelData> getType()
+        {
+            return ModelData.class;
+        }
+
+        public ModelData intoCache( ModelData data )
+        {
+            Model model = ( data.getModel() != null ) ? data.getModel().clone() : null;
+            return new ModelData( data.getSource(), model, data.getGroupId(), data.getArtifactId(), data.getVersion() );
+        }
+
+        public ModelData fromCache( ModelData data )
+        {
+            return intoCache( data );
+        }
+
+    };
+
+    /**
+     * The tag used to denote an effective dependency management section from an imported model.
+     */
+    ModelCacheTag<DependencyManagement> IMPORT = new ModelCacheTag<DependencyManagement>()
+    {
+
+        public String getName()
+        {
+            return "import";
+        }
+
+        public Class<DependencyManagement> getType()
+        {
+            return DependencyManagement.class;
+        }
+
+        public DependencyManagement intoCache( DependencyManagement data )
+        {
+            return ( data != null ) ? data.clone() : null;
+        }
+
+        public DependencyManagement fromCache( DependencyManagement data )
+        {
+            return intoCache( data );
+        }
+
+    };
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelData.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelData.java
@@ -1,0 +1,223 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+
+/**
+ * Holds a model along with some auxiliary information. This internal utility class assists the model builder during POM
+ * processing by providing a means to transport information that cannot be (easily) extracted from the model itself.
+ * 
+ * @author Benjamin Bentmann
+ */
+class ModelData
+{
+    private final ModelSource source;
+
+    private Model model;
+
+    private Model rawModel;
+
+    private List<Profile> activeProfiles;
+
+    private String groupId;
+
+    private String artifactId;
+
+    private String version;
+
+    /**
+     * Creates a new container for the specified model.
+     * 
+     * @param model The model to wrap, may be {@code null}.
+     */
+    public ModelData( ModelSource source, Model model )
+    {
+        this.source = source;
+        this.model = model;
+    }
+
+    /**
+     * Creates a new container for the specified model.
+     * 
+     * @param model The model to wrap, may be {@code null}.
+     * @param groupId The effective group identifier of the model, may be {@code null}.
+     * @param artifactId The effective artifact identifier of the model, may be {@code null}.
+     * @param version The effective version of the model, may be {@code null}.
+     */
+    public ModelData( ModelSource source, Model model, String groupId, String artifactId, String version )
+    {
+        this.source = source;
+        this.model = model;
+        setGroupId( groupId );
+        setArtifactId( artifactId );
+        setVersion( version );
+    }
+
+    public ModelSource getSource()
+    {
+        return source;
+    }
+
+    /**
+     * Gets the model being wrapped.
+     * 
+     * @return The model or {@code null} if not set.
+     */
+    public Model getModel()
+    {
+        return model;
+    }
+
+    /**
+     * Sets the model being wrapped.
+     * 
+     * @param model The model, may be {@code null}.
+     */
+    public void setModel( Model model )
+    {
+        this.model = model;
+    }
+
+    /**
+     * Gets the raw model being wrapped.
+     * 
+     * @return The raw model or {@code null} if not set.
+     */
+    public Model getRawModel()
+    {
+        return rawModel;
+    }
+
+    /**
+     * Sets the raw model being wrapped.
+     * 
+     * @param rawModel The raw model, may be {@code null}.
+     */
+    public void setRawModel( Model rawModel )
+    {
+        this.rawModel = rawModel;
+    }
+
+    /**
+     * Gets the active profiles from the model.
+     * 
+     * @return The active profiles or {@code null} if not set.
+     */
+    public List<Profile> getActiveProfiles()
+    {
+        return activeProfiles;
+    }
+
+    /**
+     * Sets the active profiles from the model.
+     * 
+     * @param activeProfiles The active profiles, may be {@code null}.
+     */
+    public void setActiveProfiles( List<Profile> activeProfiles )
+    {
+        this.activeProfiles = activeProfiles;
+    }
+
+    /**
+     * Gets the effective group identifier of the model.
+     * 
+     * @return The effective group identifier of the model or an empty string if unknown, never {@code null}.
+     */
+    public String getGroupId()
+    {
+        return ( groupId != null ) ? groupId : "";
+    }
+
+    /**
+     * Sets the effective group identifier of the model.
+     * 
+     * @param groupId The effective group identifier of the model, may be {@code null}.
+     */
+    public void setGroupId( String groupId )
+    {
+        this.groupId = groupId;
+    }
+
+    /**
+     * Gets the effective artifact identifier of the model.
+     * 
+     * @return The effective artifact identifier of the model or an empty string if unknown, never {@code null}.
+     */
+    public String getArtifactId()
+    {
+        return ( artifactId != null ) ? artifactId : "";
+    }
+
+    /**
+     * Sets the effective artifact identifier of the model.
+     * 
+     * @param artifactId The effective artifact identifier of the model, may be {@code null}.
+     */
+    public void setArtifactId( String artifactId )
+    {
+        this.artifactId = artifactId;
+    }
+
+    /**
+     * Gets the effective version of the model.
+     * 
+     * @return The effective version of the model or an empty string if unknown, never {@code null}.
+     */
+    public String getVersion()
+    {
+        return ( version != null ) ? version : "";
+    }
+
+    /**
+     * Sets the effective version of the model.
+     * 
+     * @param version The effective version of the model, may be {@code null}.
+     */
+    public void setVersion( String version )
+    {
+        this.version = version;
+    }
+
+    /**
+     * Gets the effective identifier of the model in the form {@code <groupId>:<artifactId>:<version>}.
+     * 
+     * @return The effective identifier of the model, never {@code null}.
+     */
+    public String getId()
+    {
+        StringBuilder buffer = new StringBuilder( 96 );
+
+        buffer.append( getGroupId() ).append( ':' ).append( getArtifactId() ).append( ':' ).append( getVersion() );
+
+        return buffer.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.valueOf( model );
+    }
+
+}

--- a/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelProblemUtils.java
+++ b/src/main/java/com/sourcegraph/javagraph/maven/vendored/ModelProblemUtils.java
@@ -1,0 +1,172 @@
+package com.sourcegraph.javagraph.maven.vendored;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+import org.apache.maven.model.building.*;
+import org.apache.maven.model.Model;
+
+/**
+ * Assists in the handling of model problems.
+ * 
+ * @author Benjamin Bentmann
+ */
+public class ModelProblemUtils
+{
+
+    /**
+     * Creates a user-friendly source hint for the specified model.
+     * 
+     * @param model The model to create a source hint for, may be {@code null}.
+     * @return The user-friendly source hint, never {@code null}.
+     */
+    static String toSourceHint( Model model )
+    {
+        if ( model == null )
+        {
+            return "";
+        }
+
+        StringBuilder buffer = new StringBuilder( 192 );
+
+        buffer.append( toId( model ) );
+
+        File pomFile = model.getPomFile();
+        if ( pomFile != null )
+        {
+            buffer.append( " (" ).append( pomFile ).append( ")" );
+        }
+
+        return buffer.toString();
+    }
+
+    static String toPath( Model model )
+    {
+        String path = "";
+
+        if ( model != null )
+        {
+            File pomFile = model.getPomFile();
+
+            if ( pomFile != null )
+            {
+                path = pomFile.getAbsolutePath();
+            }
+        }
+
+        return path;
+    }
+
+    static String toId( Model model )
+    {
+        if ( model == null )
+        {
+            return "";
+        }
+
+        String groupId = model.getGroupId();
+        if ( groupId == null && model.getParent() != null )
+        {
+            groupId = model.getParent().getGroupId();
+        }
+
+        String artifactId = model.getArtifactId();
+
+        String version = model.getVersion();
+        if ( version == null )
+        {
+            version = "[unknown-version]";
+        }
+
+        return toId( groupId, artifactId, version );
+    }
+
+    /**
+     * Creates a user-friendly artifact id from the specified coordinates.
+     * 
+     * @param groupId The group id, may be {@code null}.
+     * @param artifactId The artifact id, may be {@code null}.
+     * @param version The version, may be {@code null}.
+     * @return The user-friendly artifact id, never {@code null}.
+     */
+    static String toId( String groupId, String artifactId, String version )
+    {
+        StringBuilder buffer = new StringBuilder( 96 );
+
+        buffer.append( ( groupId != null && groupId.length() > 0 ) ? groupId : "[unknown-group-id]" );
+        buffer.append( ':' );
+        buffer.append( ( artifactId != null && artifactId.length() > 0 ) ? artifactId : "[unknown-artifact-id]" );
+        buffer.append( ':' );
+        buffer.append( ( version != null && version.length() > 0 ) ? version : "[unknown-version]" );
+
+        return buffer.toString();
+    }
+
+    /**
+     * Creates a string with all location details for the specified model problem. If the project identifier is
+     * provided, the generated location will omit the model id and source information and only give line/column
+     * information for problems originating directly from this POM.
+     * 
+     * @param problem The problem whose location should be formatted, must not be {@code null}.
+     * @param projectId The {@code <groupId>:<artifactId>:<version>} of the corresponding project, may be {@code null}
+     *            to force output of model id and source.
+     * @return The formatted problem location or an empty string if unknown, never {@code null}.
+     */
+    public static String formatLocation( ModelProblem problem, String projectId )
+    {
+        StringBuilder buffer = new StringBuilder( 256 );
+
+        if ( !problem.getModelId().equals( projectId ) )
+        {
+            buffer.append( problem.getModelId() );
+
+            if ( problem.getSource().length() > 0 )
+            {
+                if ( buffer.length() > 0 )
+                {
+                    buffer.append( ", " );
+                }
+                buffer.append( problem.getSource() );
+            }
+        }
+
+        if ( problem.getLineNumber() > 0 )
+        {
+            if ( buffer.length() > 0 )
+            {
+                buffer.append( ", " );
+            }
+            buffer.append( "line " ).append( problem.getLineNumber() );
+        }
+
+        if ( problem.getColumnNumber() > 0 )
+        {
+            if ( buffer.length() > 0 )
+            {
+                buffer.append( ", " );
+            }
+            buffer.append( "column " ).append( problem.getColumnNumber() );
+        }
+
+        return buffer.toString();
+    }
+
+}


### PR DESCRIPTION
## Description

A ton of maven projects try to download parent POM's externally, and were failing, causing FOSSA to show "0 Dependencies". This PR makes this step optional, allowing srclib-java to still pick up dependencies if an error is thrown trying to download parent POM files.

## Changes

All new files are vendored from: https://github.com/apache/maven/tree/maven-3.2.3

In addition to copying vendored code, we also make the following changes:

### Change 1:

https://github.com/apache/maven/blob/33f8c3e1027c3ddde99d3cdebad2656a31e8fdf4/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java#L309

We now wrap the `readParent` call in a try/catch so that it doesn't completely fail the toolchain (see `src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilder.java`: 

https://github.com/fossas/srclib-java/compare/master...fossas:optional-parent-pom?expand=1#diff-7eaf4fded50780c1825ca48bf3e4873213c4acc04534b6d8350ce73085bc83a6R321)

### Change 2:

https://github.com/apache/maven/blob/maven-3.2.3/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java#L925

The `FATAL` is changed to a `WARNING` so it doesn't throw (see `src/main/java/com/sourcegraph/javagraph/maven/vendored/DefaultModelBuilder.java`: https://github.com/fossas/srclib-java/compare/master...fossas:optional-parent-pom?expand=1#diff-7eaf4fded50780c1825ca48bf3e4873213c4acc04534b6d8350ce73085bc83a6R938)

## Testing

To test, you should first try importing a project locally on the `develop` branch in fossa core. It should show 
You can fork and import this as a good example: https://github.com/anuccio1/nanohttpd.

This should show up with 0 dependencies.

After that is done, point your image at `quay.io/fossa/fossa:srclibjava-parentpom-docker-build-28fdf7dd`, and try analyzing a different commit.

This should show up with ~56 dependencies (non-zero).


## Notes
For previous Build failure logs, you can view this build log:

(located here: https://app.fossa.com/projects/git%2Bgithub.com%2Fgp-fossa%2Fnanohttpd/refs/branch/master/efb2ebf85a2b06f7c508aba9eaad5377e3a01e81/browse/dependencies)

Org: FOSSA
Project: NanoHttpd

GH link: https://github.com/anuccio1/nanohttpd
[build-5577658.log](https://github.com/fossas/srclib-java/files/5776791/build-5577658.1.log)
